### PR TITLE
Add XCTest for axis range

### DIFF
--- a/DynaVibeTests/AxisRangeTests.swift
+++ b/DynaVibeTests/AxisRangeTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import DynaVibe
+
+final class AxisRangeTests: XCTestCase {
+    func testNiceAxisRangeAndTicksSimpleRange() {
+        let viewModel = AccelerationViewModel()
+        let result = viewModel.niceAxisRangeAndTicks(min: 0, max: 10, maxTicks: 5)
+        XCTAssertEqual(result.tickSpacing, 2, accuracy: 0.0001)
+        XCTAssertEqual(result.niceMin, 0, accuracy: 0.0001)
+        XCTAssertEqual(result.niceMax, 10, accuracy: 0.0001)
+        XCTAssertEqual(result.ticks, [0, 2, 4, 6, 8, 10])
+    }
+}


### PR DESCRIPTION
## Summary
- add `DynaVibeTests` target directory
- create `AxisRangeTests` verifying `niceAxisRangeAndTicks`

## Testing
- `xcodebuild test -project DynaVibe.xcodeproj -scheme DynaVibe -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b613d220083269f03787e2bbd37d1