### PR TITLE
Store completed measurements per project

### DIFF
--- a/DynaVibe/Models/Measurement.swift
+++ b/DynaVibe/Models/Measurement.swift
@@ -1,0 +1,19 @@
+struct Measurement: Identifiable {
+    let id = UUID()
+    let date: Date
+    let timeSeriesData: [Axis: [DataPoint]]
+    let fftFrequencies: [Double]
+    let fftMagnitudes: [Axis: [Double]]
+    let rmsX: Double?
+    let rmsY: Double?
+    let rmsZ: Double?
+    let minX: Double?
+    let maxX: Double?
+    let minY: Double?
+    let maxY: Double?
+    let minZ: Double?
+    let maxZ: Double?
+    let peakFrequencyX: Double?
+    let peakFrequencyY: Double?
+    let peakFrequencyZ: Double?
+}

--- a/DynaVibe/UI/ContentView.swift
+++ b/DynaVibe/UI/ContentView.swift
@@ -2,9 +2,10 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var selectedTab = 0
+    @State private var activeProject = Project(name: "Default Project", description: "")
     var body: some View {
         TabView(selection: $selectedTab) {
-            RealTimeDataView()
+            RealTimeDataView(project: $activeProject)
                 .tabItem {
                     Image(systemName: "waveform.path.ecg")
                     Text("Real-Time Data")

--- a/DynaVibe/UI/ProjectsView.swift
+++ b/DynaVibe/UI/ProjectsView.swift
@@ -44,8 +44,9 @@ struct ProjectsView: View {
 // Placeholder model and new project form
 struct Project: Identifiable {
     let id = UUID()
-    let name: String
-    let description: String
+    var name: String
+    var description: String
+    var measurements: [Measurement] = []
 }
 
 struct NewProjectView: View {


### PR DESCRIPTION
## Summary
- track the active `Project` in `RealTimeDataView`
- save recorded data and metrics as a new `Measurement`
- reset the view model after saving
- keep a project in `ContentView`
- allow projects to store measurements
- add a basic `Measurement` model

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b618d01c0832693798073d2a72680