### PR TITLE
Remove unused loading state from MultiLineGraphView

### DIFF
--- a/DynaVibe/UI/MultiLineGraphView.swift
+++ b/DynaVibe/UI/MultiLineGraphView.swift
@@ -20,9 +20,7 @@ public struct MultiLineGraphView: View {
     
     @State private var selectedX: Double? = nil
     @State private var showCursorInfo: Bool = false
-    @State private var isLoading: Bool = false
     @State private var chartXRange: ClosedRange<Double>? = nil // For zoom/pan
-    @GestureState private var dragOffset: CGSize = .zero
 
     public var body: some View {
         VStack(spacing: 8) {
@@ -77,11 +75,6 @@ public struct MultiLineGraphView: View {
                     setDefaultCursorPosition(for: newData)
                 }
                 .gesture(zoomAndPanGesture())
-                if isLoading {
-                    ProgressView().scaleEffect(1.5)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .background(Color.white.opacity(0.5))
-                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- clean up `MultiLineGraphView` by deleting unused state variables
- drop the always-hidden `ProgressView`

## Testing
- `swiftc DynaVibe/UI/MultiLineGraphView.swift -emit-library -o /tmp/libdummy.so` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684b60cfb91c832684195bcf46f89e4f