### PR TITLE
Show FFT progress in graph

### DIFF
--- a/DynaVibe/UI/MultiLineGraphView.swift
+++ b/DynaVibe/UI/MultiLineGraphView.swift
@@ -17,12 +17,36 @@ public struct MultiLineGraphView: View {
     let yTicks: [Double] // Y axis tick values
     let xGridLines: [Double]? // X axis grid line values (optional)
     let yGridLines: [Double]? // Y axis grid line values (optional)
-    
+
     @State private var selectedX: Double? = nil
     @State private var showCursorInfo: Bool = false
-    @State private var isLoading: Bool = false
+    @Binding var isLoading: Bool
     @State private var chartXRange: ClosedRange<Double>? = nil // For zoom/pan
     @GestureState private var dragOffset: CGSize = .zero
+
+    public init(
+        plotData: [IdentifiableGraphPoint],
+        ranges: AxisRanges,
+        isFrequencyDomain: Bool,
+        axisColors: [Axis: Color],
+        yAxisLabelUnit: String,
+        xTicks: [Double],
+        yTicks: [Double],
+        xGridLines: [Double]?,
+        yGridLines: [Double]?,
+        isLoading: Binding<Bool>
+    ) {
+        self.plotData = plotData
+        self.ranges = ranges
+        self.isFrequencyDomain = isFrequencyDomain
+        self.axisColors = axisColors
+        self.yAxisLabelUnit = yAxisLabelUnit
+        self.xTicks = xTicks
+        self.yTicks = yTicks
+        self.xGridLines = xGridLines
+        self.yGridLines = yGridLines
+        self._isLoading = isLoading
+    }
 
     public var body: some View {
         VStack(spacing: 8) {
@@ -243,7 +267,8 @@ private struct MultiLineGraphView_PreviewHelper {
         xTicks: Array(stride(from: 0, through: 2, by: 0.5)), // Example ticks
         yTicks: Array(stride(from: -1.5, through: 1.5, by: 0.5)), // Example ticks
         xGridLines: nil,
-        yGridLines: nil
+        yGridLines: nil,
+        isLoading: .constant(false)
     )
     .padding()
     .frame(height: 250)

--- a/DynaVibe/UI/RealTimeDataView.swift
+++ b/DynaVibe/UI/RealTimeDataView.swift
@@ -35,7 +35,8 @@ struct RealTimeDataView: View {
                     xTicks: xTicks,
                     yTicks: yTicks,
                     xGridLines: xGridLines,
-                    yGridLines: yGridLines
+                    yGridLines: yGridLines,
+                    isLoading: $vm.isComputingFFT
                 )
                 .frame(minHeight: 200, idealHeight: 250, maxHeight: .infinity)
                 .background(Color(UIColor.systemGray6))

--- a/DynaVibe/ViewModels/AccelerationViewModel.swift
+++ b/DynaVibe/ViewModels/AccelerationViewModel.swift
@@ -21,6 +21,7 @@ final class AccelerationViewModel: ObservableObject {
     @Published var rmsZ: Double? = nil
 
     @Published var isFFTReady = false
+    @Published var isComputingFFT = false
     @Published var timeLeft: Double = 0.0
     @Published var elapsedTime: Double = 0.0
     
@@ -175,9 +176,11 @@ final class AccelerationViewModel: ObservableObject {
     func computeFFT() async {
         guard collectedSamplesCount > 1, let rateForFFT = calculatedActualAverageSamplingRateForFFT else {
             isFFTReady = false
+            isComputingFFT = false
             return
         }
-        
+
+        isComputingFFT = true
         isFFTReady = false
         let xValues = (timeSeriesData[.x] ?? []).map { $0.value }
         let yValues = (timeSeriesData[.y] ?? []).map { $0.value }
@@ -195,6 +198,7 @@ final class AccelerationViewModel: ObservableObject {
         fftMagnitudes[.z] = zMag
         fftFrequencies = freqs
         isFFTReady = true
+        isComputingFFT = false
     }
     
     func exportCSV() {
@@ -287,7 +291,7 @@ final class AccelerationViewModel: ObservableObject {
 
     private func resetDataForNewRecording() {
         timeSeriesData = [.x: [], .y: [], .z: []]; fftMagnitudes = [:]; fftFrequencies = []
-        isFFTReady = false; rmsX = nil; rmsY = nil; rmsZ = nil
+        isFFTReady = false; isComputingFFT = false; rmsX = nil; rmsY = nil; rmsZ = nil
         latestX = 0; latestY = 0; latestZ = 0; currentRoll = 0; currentPitch = 0
         calculatedActualAverageSamplingRateForFFT = nil
         recorder.clear()


### PR DESCRIPTION
## Summary
- publish an `isComputingFFT` flag in `AccelerationViewModel`
- toggle the flag around FFT calculations and on reset
- allow `MultiLineGraphView` to receive an external loading binding
- show progress indicator while the FFT is calculated

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b60dc1d808326bd9d72c29bed2834