### PR TITLE
Add project creation workflow and assessment flow

### DIFF
--- a/DynaVibe/Models/Project.swift
+++ b/DynaVibe/Models/Project.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+enum ProjectType: String, CaseIterable, Identifiable, Codable {
+    case timeHistory = "Time History"
+    case floorVibration = "Floor Vibration"
+    var id: String { rawValue }
+}
+
+enum BuildingType: String, CaseIterable, Identifiable, Codable {
+    case office = "Office"
+    case residential = "Residential"
+    case industrial = "Industrial"
+    var id: String { rawValue }
+}
+
+enum ConstructionMaterial: String, CaseIterable, Identifiable, Codable {
+    case concrete = "Concrete"
+    case steel = "Steel"
+    case wood = "Wood"
+    var id: String { rawValue }
+}
+
+struct Project: Identifiable, Codable {
+    let id: UUID = UUID()
+    var name: String
+    var description: String
+    var type: ProjectType
+    var buildingType: BuildingType?
+    var constructionMaterial: ConstructionMaterial?
+    var subjectiveResponses: [String: String]? = nil
+    var measurements: [Measurement] = []
+}

--- a/DynaVibe/UI/AssessmentFlowView.swift
+++ b/DynaVibe/UI/AssessmentFlowView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct AssessmentFlowView: View {
+    @Binding var project: Project
+    @State private var step: Step = .setup
+
+    enum Step {
+        case setup, measurement, review
+    }
+
+    private var dateFormatter: DateFormatter {
+        let df = DateFormatter()
+        df.dateStyle = .medium
+        df.timeStyle = .short
+        return df
+    }
+
+    var body: some View {
+        switch step {
+        case .setup:
+            VStack(spacing: 20) {
+                Text(setupTitle)
+                    .font(.headline)
+                Text(setupDescription)
+                    .multilineTextAlignment(.center)
+                    .padding()
+                Button("Start Measurement") { step = .measurement }
+                    .buttonStyle(.borderedProminent)
+            }
+            .navigationTitle("Setup")
+        case .measurement:
+            RealTimeDataView(project: $project)
+                .navigationBarItems(trailing: Button("Next") { step = .review })
+        case .review:
+            List(project.measurements) { m in
+                Text("Measurement on \(m.date, formatter: dateFormatter)")
+            }
+            .navigationTitle("Results")
+        }
+    }
+
+    private var setupTitle: String {
+        project.type == .floorVibration ? "Floor Vibration Setup" : "Measurement Setup"
+    }
+
+    private var setupDescription: String {
+        switch project.type {
+        case .floorVibration:
+            return "Place the sensor on the floor and ensure proper contact before starting the recording."
+        case .timeHistory:
+            return "Prepare to record time history data."
+        }
+    }
+}

--- a/DynaVibe/UI/ContentView.swift
+++ b/DynaVibe/UI/ContentView.swift
@@ -2,19 +2,19 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var selectedTab = 0
-    @State private var activeProject = Project(name: "Default Project", description: "")
+    @State private var activeProject = Project(name: "Default Project", description: "", type: .timeHistory)
     var body: some View {
         TabView(selection: $selectedTab) {
-            RealTimeDataView(project: $activeProject)
-                .tabItem {
-                    Image(systemName: "waveform.path.ecg")
-                    Text("Real-Time Data")
-                }
-                .tag(0)
             ProjectsView()
                 .tabItem {
                     Image(systemName: "folder")
                     Text("Projects")
+                }
+                .tag(0)
+            RealTimeDataView(project: $activeProject)
+                .tabItem {
+                    Image(systemName: "waveform.path.ecg")
+                    Text("Real-Time Data")
                 }
                 .tag(1)
             SettingsView()
@@ -32,9 +32,9 @@ struct ContentView: View {
         }
         .onChange(of: selectedTab) { oldValue, newValue in
             if newValue == 0 {
-                print("Switched to Real-Time Data")
-            } else if newValue == 1 {
                 print("Switched to Projects")
+            } else if newValue == 1 {
+                print("Switched to Real-Time Data")
             } else if newValue == 2 {
                 print("Switched to Settings")
             }

--- a/DynaVibe/UI/RealTimeDataView.swift
+++ b/DynaVibe/UI/RealTimeDataView.swift
@@ -303,6 +303,6 @@ struct ControlButtonModifier: ViewModifier {
 
 struct RealTimeDataView_Previews: PreviewProvider {
     static var previews: some View {
-        RealTimeDataView(project: .constant(Project(name: "Preview", description: "")))
+        RealTimeDataView(project: .constant(Project(name: "Preview", description: "", type: .timeHistory)))
     }
 }


### PR DESCRIPTION
## Summary
- add `Project` model with project type and building metadata
- extend new project form with options for vibration projects
- start app on Projects tab and show project type
- add step-by-step AssessmentFlowView
- update real-time view preview

## Testing
- `swift -version`
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685437f8f7348326a755949efd3cf5da